### PR TITLE
Redstone Torch Fix

### DIFF
--- a/assets/minecraft/blockstates/redstone_torch.json
+++ b/assets/minecraft/blockstates/redstone_torch.json
@@ -2,6 +2,6 @@
 	"__comment": "Made by Shadow204, part of the 'Fairth 32x' resource pack|with Cubic Studio|All rights reserved.",
     "variants": {
         "lit=true":  { "model": "block/torch/torch_off" },
-        "lit=false":  { "model": "block/torch/redstone_torch_off" }
+        "lit=false":  { "model": "block/torch/torch_off" }
     }
 }

--- a/assets/minecraft/blockstates/redstone_wall_torch.json
+++ b/assets/minecraft/blockstates/redstone_wall_torch.json
@@ -6,9 +6,9 @@
         "facing=west,lit=true":  { "model": "block/torch/torch_off_wall", "y": 180 },
         "facing=north,lit=true":  { "model": "block/torch/torch_off_wall", "y": 270 },
 		
-        "facing=east,lit=false":  { "model": "block/torch/redstone_wall_torch_off" },
-        "facing=south,lit=false":  { "model": "block/torch/redstone_wall_torch_off", "y": 90 },
-        "facing=west,lit=false":  { "model": "block/torch/redstone_wall_torch_off", "y": 180 },
-        "facing=north,lit=false":  { "model": "block/torch/redstone_wall_torch_off", "y": 270 }
+        "facing=east,lit=false":  { "model": "block/torch/torch_off_wall" },
+        "facing=south,lit=false":  { "model": "block/torch/torch_off_wall", "y": 90 },
+        "facing=west,lit=false":  { "model": "block/torch/torch_off_wall", "y": 180 },
+        "facing=north,lit=false":  { "model": "block/torch/torch_off_wall", "y": 270 }
     }
 }


### PR DESCRIPTION
When a redstone torch is off, it now displays the correct model.